### PR TITLE
Fix Issue #1: Enhance AI prompts to strictly prevent code snippets in implementation steps

### DIFF
--- a/src/ai/flows/research-task.ts
+++ b/src/ai/flows/research-task.ts
@@ -28,7 +28,7 @@ const ResearchTaskOutputSchema = z.object({
   implementationSteps: z
     .string()
     .describe(
-      `Provide a detailed, step-by-step implementation guide. Avoid including actual code snippets or implementations. Focus on:
+      `Provide a detailed, step-by-step implementation guide. Must not include actual code snippets or implementations. Focus on:
 - Files that need to be created or modified
 - Functions/components that need to be implemented
 - Integration points with other system components
@@ -47,7 +47,7 @@ You MUST return your response as a valid JSON object that conforms to the output
 
 For the given task, provide a detailed breakdown for each of the following fields:
 - context: Briefly explain how this task fits into the overall architecture.
-- implementationSteps: Provide a detailed, step-by-step implementation guide. Avoid including actual code snippets or implementations. Focus on:
+- implementationSteps: Provide a detailed, step-by-step implementation guide. Must not include actual code snippets or implementations. Focus on:
   - Files that need to be created or modified
   - Functions/components that need to be implemented
   - Integration points with other system components
@@ -75,7 +75,7 @@ You MUST return your response as a valid JSON object that conforms to the output
 
 For the given task, provide a detailed breakdown for each of the following fields:
 - context: Briefly explain how this task fits into the overall architecture.
-- implementationSteps: Provide a detailed, step-by-step implementation guide. Avoid including actual code snippets or implementations. Focus on:
+- implementationSteps: Provide a detailed, step-by-step implementation guide. Must not include actual code snippets or implementations. Focus on:
   - Files that need to be created or modified
   - Functions/components that need to be implemented
   - Integration points with other system components

--- a/src/ai/flows/research-task.ts
+++ b/src/ai/flows/research-task.ts
@@ -28,7 +28,7 @@ const ResearchTaskOutputSchema = z.object({
   implementationSteps: z
     .string()
     .describe(
-      `Provide a detailed, step-by-step implementation guide. Describe what needs to be implemented without including actual code snippets. Focus on:
+      `Provide a detailed, step-by-step implementation guide. DO NOT include actual code snippets or implementations. Focus on:
 - Files that need to be created or modified
 - Functions/components that need to be implemented
 - Integration points with other system components
@@ -47,12 +47,12 @@ You MUST return your response as a valid JSON object that conforms to the output
 
 For the given task, provide a detailed breakdown for each of the following fields:
 - context: Briefly explain how this task fits into the overall architecture.
-- implementationSteps: Provide a detailed, step-by-step implementation guide. Describe what needs to be implemented without including actual code snippets. Focus on:
+- implementationSteps: Provide a detailed, step-by-step implementation guide. DO NOT include actual code snippets or implementations. Focus on:
   - Files that need to be created or modified
   - Functions/components that need to be implemented
   - Integration points with other system components
   - The expected behavior and functionality
-  - Any specific considerations or edge cases
+  - Any specific considerations or edge cases. Use pseudocode, library documentation references, or high-level descriptions instead of actual code.
 - acceptanceCriteria: Define what it means for this task to be considered "done".
 
 Overall Project Architecture:
@@ -75,12 +75,12 @@ You MUST return your response as a valid JSON object that conforms to the output
 
 For the given task, provide a detailed breakdown for each of the following fields:
 - context: Briefly explain how this task fits into the overall architecture.
-- implementationSteps: Provide a detailed, step-by-step implementation guide. Describe what needs to be implemented without including actual code snippets. Focus on:
+- implementationSteps: Provide a detailed, step-by-step implementation guide. DO NOT include actual code snippets or implementations. Focus on:
   - Files that need to be created or modified
   - Functions/components that need to be implemented
   - Integration points with other system components
   - The expected behavior and functionality
-  - Any specific considerations or edge cases. The implementation plan must strictly follow all phases of Test-Driven Development (Red-Green-Refactor).
+  - Any specific considerations or edge cases. The implementation plan must strictly follow all phases of Test-Driven Development (Red-Green-Refactor). Use pseudocode, library documentation references, or high-level descriptions instead of actual code.
 - acceptanceCriteria: Define what it means for this task to be considered "done".
 
 Overall Project Architecture:

--- a/src/ai/flows/research-task.ts
+++ b/src/ai/flows/research-task.ts
@@ -28,7 +28,7 @@ const ResearchTaskOutputSchema = z.object({
   implementationSteps: z
     .string()
     .describe(
-      `Provide a detailed, step-by-step implementation guide. Must not include actual code snippets or implementations. Focus on:
+      `Provide a detailed, step-by-step implementation guide. Avoid including actual code snippets or implementations. Focus on:
 - Files that need to be created or modified
 - Functions/components that need to be implemented
 - Integration points with other system components
@@ -47,7 +47,7 @@ You MUST return your response as a valid JSON object that conforms to the output
 
 For the given task, provide a detailed breakdown for each of the following fields:
 - context: Briefly explain how this task fits into the overall architecture.
-- implementationSteps: Provide a detailed, step-by-step implementation guide. Must not include actual code snippets or implementations. Focus on:
+- implementationSteps: Provide a detailed, step-by-step implementation guide. Avoid including actual code snippets or implementations. Focus on:
   - Files that need to be created or modified
   - Functions/components that need to be implemented
   - Integration points with other system components
@@ -75,7 +75,7 @@ You MUST return your response as a valid JSON object that conforms to the output
 
 For the given task, provide a detailed breakdown for each of the following fields:
 - context: Briefly explain how this task fits into the overall architecture.
-- implementationSteps: Provide a detailed, step-by-step implementation guide. Must not include actual code snippets or implementations. Focus on:
+- implementationSteps: Provide a detailed, step-by-step implementation guide. Avoid including actual code snippets or implementations. Focus on:
   - Files that need to be created or modified
   - Functions/components that need to be implemented
   - Integration points with other system components

--- a/src/ai/flows/research-task.ts
+++ b/src/ai/flows/research-task.ts
@@ -28,7 +28,7 @@ const ResearchTaskOutputSchema = z.object({
   implementationSteps: z
     .string()
     .describe(
-      `Provide a detailed, step-by-step implementation guide. DO NOT include actual code snippets or implementations. Focus on:
+      `Provide a detailed, step-by-step implementation guide. Must not include actual code snippets or implementations. Focus on:
 - Files that need to be created or modified
 - Functions/components that need to be implemented
 - Integration points with other system components
@@ -47,7 +47,7 @@ You MUST return your response as a valid JSON object that conforms to the output
 
 For the given task, provide a detailed breakdown for each of the following fields:
 - context: Briefly explain how this task fits into the overall architecture.
-- implementationSteps: Provide a detailed, step-by-step implementation guide. DO NOT include actual code snippets or implementations. Focus on:
+- implementationSteps: Provide a detailed, step-by-step implementation guide. Must not include actual code snippets or implementations. Focus on:
   - Files that need to be created or modified
   - Functions/components that need to be implemented
   - Integration points with other system components
@@ -75,7 +75,7 @@ You MUST return your response as a valid JSON object that conforms to the output
 
 For the given task, provide a detailed breakdown for each of the following fields:
 - context: Briefly explain how this task fits into the overall architecture.
-- implementationSteps: Provide a detailed, step-by-step implementation guide. DO NOT include actual code snippets or implementations. Focus on:
+- implementationSteps: Provide a detailed, step-by-step implementation guide. Must not include actual code snippets or implementations. Focus on:
   - Files that need to be created or modified
   - Functions/components that need to be implemented
   - Integration points with other system components


### PR DESCRIPTION

This PR addresses the ongoing issue where tasks generate demo code instead of implementation documentation.

## Changes Made

1. **Enhanced AI Prompts**: Updated both standard and TDD prompts in `research-task.ts` to be more explicit about not including code snippets:
   - Added "DO NOT include actual code snippets or implementations" language
   - Provided guidance to use pseudocode, library documentation references, or high-level descriptions instead of actual code
   - Made the instructions clearer to prevent AI from generating demo implementations

2. **Maintained UI Changes**: The previous UI changes (removing font-mono from task details) remain in place to visually distinguish documentation from code.

## Why This Fixes the Issue

The previous fix partially addressed the problem by updating the prompts, but the AI was still generating code snippets. This enhancement makes the instructions much more explicit and provides clear alternatives to including actual code.

The changes focus on:
- Making the "no code snippets" requirement more prominent
- Providing specific guidance on what to include instead of code
- Maintaining the documentation-focused approach while being more strict about implementation details

This should result in task details that contain clear, actionable implementation guidance without including incomplete demo code.

Closes #1
