### PR TITLE
feat: Add Temperature Parameter Support to Settings UI and LLM Configuration

### DIFF
--- a/src/ai/flows/generate-agents-md.ts
+++ b/src/ai/flows/generate-agents-md.ts
@@ -51,7 +51,8 @@ export async function generateAgentsMd(
   input: GenerateAgentsMdInput,
   apiKey?: string,
   model?: string,
-  apiBase?: string
+  apiBase?: string,
+  temperature?: number
 ): Promise<GenerateAgentsMdOutput> {
   if (!model) {
     throw new Error('Model is required. Please provide a model in "provider/model" format in settings.');
@@ -97,7 +98,8 @@ Content should be concise but comprehensive, providing valuable guidance for AI 
 **IMPORTANT: Output ONLY markdown content. DO NOT output JSON format. Do not wrap your response in JSON objects or use any JSON structure.**`,
     config: (apiKey || apiBase) ? {
       ...(apiKey && {apiKey}),
-      ...(apiBase && {apiBase})
+      ...(apiBase && {apiBase}),
+      ...(temperature !== undefined && {temperature})
     } : undefined,
   });
 

--- a/src/ai/flows/generate-architecture.ts
+++ b/src/ai/flows/generate-architecture.ts
@@ -37,7 +37,8 @@ export async function generateArchitecture(
   input: GenerateArchitectureInput,
   apiKey?: string,
   model?: string,
-  apiBase?: string
+  apiBase?: string,
+  temperature?: number
 ): Promise<GenerateArchitectureOutput> {
   if (!model) {
     throw new Error('Model is required. Please provide a model in "provider/model" format in settings.');
@@ -89,7 +90,8 @@ You must structure your response with two main sections separated by a markdown 
 **IMPORTANT: Output ONLY markdown content. DO NOT output JSON format. Do not wrap your response in JSON objects or use any JSON structure.**`,
       config: (apiKey || apiBase) ? {
         ...(apiKey && {apiKey}),
-        ...(apiBase && {apiBase})
+        ...(apiBase && {apiBase}),
+        ...(temperature !== undefined && {temperature})
       } : undefined,
     });
 

--- a/src/ai/flows/generate-file-structure.ts
+++ b/src/ai/flows/generate-file-structure.ts
@@ -63,7 +63,8 @@ export async function generateFileStructure(
   input: GenerateFileStructureInput,
   apiKey?: string,
   model?: string,
-  apiBase?: string
+  apiBase?: string,
+  temperature?: number
 ): Promise<GenerateFileStructureOutput> {
   console.log('[DEBUG] generateFileStructure called with model:', model);
   if (!model) {
@@ -83,7 +84,8 @@ export async function generateFileStructure(
       prompt: prompt,
       config: (apiKey || apiBase) ? {
         ...(apiKey && {apiKey}),
-        ...(apiBase && {apiBase})
+        ...(apiBase && {apiBase}),
+        ...(temperature !== undefined && {temperature})
       } : undefined,
     });
 

--- a/src/ai/flows/generate-tasks.ts
+++ b/src/ai/flows/generate-tasks.ts
@@ -79,7 +79,7 @@ Output format: List each task as a markdown bullet point. Do not include task de
 
 **IMPORTANT: Output ONLY markdown content with a bulleted list of task titles. DO NOT output JSON format. Do not wrap your response in JSON objects or use any JSON structure.**`;
 
-export async function generateTasks(input: GenerateTasksInput, apiKey?: string, model?: string, apiBase?: string, useTDD?: boolean): Promise<GenerateTasksOutput> {
+export async function generateTasks(input: GenerateTasksInput, apiKey?: string, model?: string, apiBase?: string, useTDD?: boolean, temperature?: number): Promise<GenerateTasksOutput> {
   if (!model) {
     throw new Error('Model is required. Please provide a model in "provider/model" format in settings.');
   }
@@ -97,7 +97,8 @@ export async function generateTasks(input: GenerateTasksInput, apiKey?: string, 
     prompt: prompt,
     config: (apiKey || apiBase) ? {
       ...(apiKey && {apiKey}),
-      ...(apiBase && {apiBase})
+      ...(apiBase && {apiBase}),
+      ...(temperature !== undefined && {temperature})
     } : undefined,
   });
   

--- a/src/ai/flows/research-task.ts
+++ b/src/ai/flows/research-task.ts
@@ -137,7 +137,8 @@ export async function researchTask(
   apiKey?: string,
   model?: string,
   apiBase?: string,
-  useTDD?: boolean
+  useTDD?: boolean,
+  temperature?: number
 ): Promise<ResearchTaskOutput> {
   if (!model) {
     throw new Error('Model is required. Please provide a model in "provider/model" format in settings.');
@@ -158,7 +159,8 @@ export async function researchTask(
       prompt: prompt,
       config: (apiKey || apiBase) ? {
         ...(apiKey && {apiKey}),
-        ...(apiBase && {apiBase})
+        ...(apiBase && {apiBase}),
+        ...(temperature !== undefined && {temperature})
       } : undefined,
     });
 

--- a/src/ai/litellm.ts
+++ b/src/ai/litellm.ts
@@ -19,6 +19,7 @@ interface GenerateOptions {
     apiKey?: string;
     apiBase?: string;
     timeout?: number; // Timeout in milliseconds
+    temperature?: number;
   };
 }
 
@@ -195,7 +196,7 @@ async function makeOpenAICall(
       body: JSON.stringify({
         model,
         messages: [{ role: 'user', content: prompt }],
-        temperature: 0.7,
+        temperature: config?.temperature ?? 0.7,
         max_tokens: 32768,
       }),
       signal: controller.signal,

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -14,6 +14,7 @@ type ActionOptions = {
   model?: string;
   apiBase?: string;
   useTDD?: boolean;
+  temperature?: number;
 };
 
 export async function runGenerateArchitecture(
@@ -28,7 +29,8 @@ export async function runGenerateArchitecture(
       input,
       options?.apiKey,
       options?.model,
-      options?.apiBase
+      options?.apiBase,
+      options?.temperature
     );
     return result;
   } catch (error) {
@@ -59,7 +61,7 @@ export async function runGenerateTasks(
     );
   }
   try {
-    const result = await generateTasks(input, options?.apiKey, options?.model, options?.apiBase, options?.useTDD);
+    const result = await generateTasks(input, options?.apiKey, options?.model, options?.apiBase, options?.useTDD, options?.temperature);
     return result;
   } catch (error) {
     console.error('Error generating tasks:', error);
@@ -89,7 +91,8 @@ export async function runGenerateFileStructure(
       input,
       options?.apiKey,
       options?.model,
-      options?.apiBase
+      options?.apiBase,
+      options?.temperature
     );
     return result;
   } catch (error) {
@@ -123,7 +126,7 @@ export async function runResearchTask(
   const MAX_RETRIES = 3;
   for (let i = 0; i < MAX_RETRIES; i++) {
     try {
-      const result = await researchTask(input, options?.apiKey, options?.model, options?.apiBase, options?.useTDD);
+      const result = await researchTask(input, options?.apiKey, options?.model, options?.apiBase, options?.useTDD, options?.temperature);
       return result;
     } catch (error) {
       console.error(
@@ -158,7 +161,8 @@ export async function runGenerateAgentsMd(
       input,
       options?.apiKey,
       options?.model,
-      options?.apiBase
+      options?.apiBase,
+      options?.temperature
     );
     return result;
   } catch (error) {

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -12,6 +12,7 @@ const SettingsSchema = z.object({
   apiKey: z.string().optional(),
   apiBase: z.string().optional(),
   useTDD: z.boolean().optional(),
+  temperature: z.number().min(0).max(2),
   documentation: DocumentationSettingsSchema.optional(),
 });
 


### PR DESCRIPTION
This PR implements feature request #35 by adding a configurable temperature parameter for LLM responses.

## Changes Made:

1. **Settings UI** (`src/app/page.tsx`):
   - Added `temperature` field to settings schema with validation (0.0-2.0) and default of 0.7
   - Added slider input in the Settings dialog with Precise/Creative labels

2. **Settings API** (`src/app/api/settings/route.ts`):
   - Updated settings schema to include temperature parameter 

3. **LiteLLM Implementation** (`src/ai/litellm.ts`):
   - Extended `GenerateOptions` interface to support temperature
   - Modified OpenAI call to use temperature from config or default to 0.7

4. **Action Layer** (`src/app/actions.ts`):
   - Updated `ActionOptions` type to include temperature 
   - Passed temperature through all action functions

5. **All AI Flows**:
   - Updated all flow functions in `/src/ai/flows/*` to accept and pass temperature parameter
   - Modified ai.generate calls to include temperature when provided

## Features:

- Users can now configure a temperature value (0.0-2.0) in the Settings UI
- Temperature is passed through to all LiteLLM calls 
- Default value of 0.7 maintains current behavior for backward compatibility
- Real-time changes affect AI response creativity based on setting