### PR TITLE
Fix CI test job to actually run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,4 +104,4 @@ jobs:
         run: npm ci
 
       - name: Run tests
-        run: echo "No test files found, skipping test execution"
+        run: npm test


### PR DESCRIPTION
This PR fixes the failing CI checks by updating the ci.yml workflow to actually run tests using `npm test` instead of skipping them with a placeholder message.

The repository already has:
- Test files in src/test/
- Jest configured with jest.config.js
- A test script defined in package.json

The only issue was that the CI workflow wasn't actually executing tests. This change ensures all existing tests are run during CI.